### PR TITLE
Addition works

### DIFF
--- a/klambda/expander.rkt
+++ b/klambda/expander.rkt
@@ -1,14 +1,23 @@
 #lang br
 
-(define-macro (klambda-module-begin PARSE-TREE)
-  #'(#%module-begin
-     'PARSE-TREE))
+(define-syntax klambda-module-begin
+  (syntax-rules ()
+    [(klambda-module-begin body) (#%module-begin body)]))
 (provide (rename-out [klambda-module-begin #%module-begin]))
 
-(define-macro (klprogram FORM ...)
-  #'(list FORM ...))
+(define-syntax klprogram
+  (syntax-rules ()
+    [(klprogram FORM ...) (begin FORM ...)]))
 (provide klprogram)
 
-(define-macro (sexp FORM ...)
-  #'(list FORM ...))
+(define-syntax sexp
+  (syntax-rules ()
+    [(sexp FORM) (FORM)]))
 (provide sexp)
+
+(define-syntax list
+  (syntax-rules ()
+    [(list FORM ...) 0]))
+(provide list)
+(provide #%datum #%app)
+

--- a/klambda/expander.rkt
+++ b/klambda/expander.rkt
@@ -1,4 +1,4 @@
-#lang br
+#lang racket
 
 (define-syntax klambda-module-begin
   (syntax-rules ()
@@ -10,14 +10,5 @@
     [(klprogram FORM ...) (begin FORM ...)]))
 (provide klprogram)
 
-(define-syntax sexp
-  (syntax-rules ()
-    [(sexp FORM) FORM]))
-(provide sexp)
-
-(define-syntax list
-  (syntax-rules ()
-    [(list FORM ...) (FORM ...)]))
-(provide list +)
-(provide #%datum #%app)
+(provide + #%datum #%app #%top-interaction)
 

--- a/klambda/expander.rkt
+++ b/klambda/expander.rkt
@@ -12,12 +12,12 @@
 
 (define-syntax sexp
   (syntax-rules ()
-    [(sexp FORM) (FORM)]))
+    [(sexp FORM) FORM]))
 (provide sexp)
 
 (define-syntax list
   (syntax-rules ()
-    [(list FORM ...) 0]))
-(provide list)
+    [(list FORM ...) (FORM ...)]))
+(provide list +)
 (provide #%datum #%app)
 

--- a/klambda/parser.rkt
+++ b/klambda/parser.rkt
@@ -1,4 +1,4 @@
 #lang brag
 klprogram : sexp*
 sexp : NUMBER | STRING | SYMBOL | list
-list : LEFT-PAREN (sexp sexp*)? RIGHT-PAREN
+list : /LEFT-PAREN (sexp sexp*)? /RIGHT-PAREN

--- a/klambda/parser.rkt
+++ b/klambda/parser.rkt
@@ -1,4 +1,4 @@
 #lang brag
 klprogram : sexp*
-sexp : NUMBER | STRING | SYMBOL | list
-list : /LEFT-PAREN (sexp sexp*)? /RIGHT-PAREN
+@sexp : NUMBER | STRING | SYMBOL | list
+/list : /LEFT-PAREN (sexp sexp*)? /RIGHT-PAREN

--- a/klambda/parser.rkt
+++ b/klambda/parser.rkt
@@ -1,5 +1,4 @@
 #lang brag
 klprogram : sexp*
-number : NUMBER
-sexp : number | STRING | SYMBOL | list
+sexp : NUMBER | STRING | SYMBOL | list
 list : LEFT-PAREN (sexp sexp*)? RIGHT-PAREN

--- a/klambda/reader.rkt
+++ b/klambda/reader.rkt
@@ -2,8 +2,8 @@
 (require "tokenizer.rkt" "parser.rkt")
 
 (define (read-syntax path port)
-  (define parse-tree (parse path (make-tokenizer port)))
-  (define module-datum `(module klambda klambda/expander
-                          ,parse-tree))
-  (datum->syntax #f module-datum))
+  (let* ([parse-tree (parse path (make-tokenizer port))]
+         [module-datum `(module klambda "expander.rkt"
+                          ,parse-tree)])
+    (datum->syntax #f module-datum)))
 (provide read-syntax)


### PR DESCRIPTION
- switch beatiful racket macros for racket macros
- omit parens, list, sexp from parse tree